### PR TITLE
brew-fix: remove unnecessary UTF comment.

### DIFF
--- a/cmd/brew-fix.rb
+++ b/cmd/brew-fix.rb
@@ -1,5 +1,3 @@
-# -*- coding: UTF-8 -*-
-
 # Description: an experimental extension to `brew style --fix`
 # Author: Baptiste Fontaine
 # Usage: brew fix <formula> [<formula> ...]


### PR DESCRIPTION
Flagged by `brew style`.